### PR TITLE
feat: tweak jest config and add more example contracts

### DIFF
--- a/contracts/hello-world.test.ts
+++ b/contracts/hello-world.test.ts
@@ -1,5 +1,6 @@
 import { TestExecutionContext } from "@algorandfoundation/algorand-typescript-testing";
 import { HelloWorldContract } from "./hello-world.algo";
+import { describe, expect, test } from "@jest/globals";
 
 describe('HelloWorldContract', () => {
   const ctx = new TestExecutionContext();

--- a/contracts/marketplace.algo.ts
+++ b/contracts/marketplace.algo.ts
@@ -1,0 +1,277 @@
+import type { Asset, gtxn, uint64 } from '@algorandfoundation/algorand-typescript'
+import { arc4, assert, BoxMap, Global, itxn, op, Txn } from '@algorandfoundation/algorand-typescript'
+
+export class ListingKey extends arc4.Struct<{
+  owner: arc4.Address
+  asset: arc4.UintN64
+  nonce: arc4.UintN64
+}> {}
+
+export class ListingValue extends arc4.Struct<{
+  deposited: arc4.UintN64
+  unitaryPrice: arc4.UintN64
+  bidder: arc4.Address
+  bid: arc4.UintN64
+  bidUnitaryPrice: arc4.UintN64
+}> {}
+
+export default class DigitalMarketplace extends arc4.Contract {
+  listings = BoxMap<ListingKey, ListingValue>({ keyPrefix: 'listings' })
+
+  listingsBoxMbr(): uint64 {
+    return (
+      2_500 +
+      // fmt: off
+      // Key length
+      (8 +
+        32 +
+        8 +
+        8 +
+        // Value length
+        8 +
+        8 +
+        32 +
+        8 +
+        8) *
+        // fmt: on
+        400
+    )
+  }
+
+  quantityPrice(quantity: uint64, price: uint64, assetDecimals: uint64): uint64 {
+    const [amountNotScaledHigh, amountNotScaledLow] = op.mulw(price, quantity)
+    const [scalingFactorHigh, scalingFactorLow] = op.expw(10, assetDecimals)
+    const [_quotientHigh, amountToBePaid, _remainderHigh, _remainderLow] = op.divmodw(
+      amountNotScaledHigh,
+      amountNotScaledLow,
+      scalingFactorHigh,
+      scalingFactorLow,
+    )
+    assert(_quotientHigh === 0)
+
+    return amountToBePaid
+  }
+
+  @arc4.abimethod({ readonly: true })
+  getListingsMbr(): uint64 {
+    return this.listingsBoxMbr()
+  }
+
+  @arc4.abimethod()
+  allowAsset(mbrPay: gtxn.PaymentTxn, asset: Asset) {
+    assert(!Global.currentApplicationAddress.isOptedIn(asset))
+
+    assert(mbrPay.receiver === Global.currentApplicationAddress)
+    assert(mbrPay.amount === Global.assetOptInMinBalance)
+
+    itxn
+      .assetTransfer({
+        xferAsset: asset,
+        assetReceiver: Global.currentApplicationAddress,
+        assetAmount: 0,
+      })
+      .submit()
+  }
+
+  @arc4.abimethod()
+  firstDeposit(mbrPay: gtxn.PaymentTxn, xfer: gtxn.AssetTransferTxn, unitaryPrice: arc4.UintN64, nonce: arc4.UintN64) {
+    assert(mbrPay.sender === Txn.sender)
+    assert(mbrPay.receiver === Global.currentApplicationAddress)
+    assert(mbrPay.amount === this.listingsBoxMbr())
+
+    const key = new ListingKey({
+      owner: new arc4.Address(Txn.sender),
+      asset: new arc4.UintN64(xfer.xferAsset.id),
+      nonce: nonce,
+    })
+    assert(!this.listings.has(key))
+
+    assert(xfer.sender === Txn.sender)
+    assert(xfer.assetReceiver === Global.currentApplicationAddress)
+    assert(xfer.assetAmount > 0)
+
+    this.listings.set(
+      key,
+      new ListingValue({
+        deposited: new arc4.UintN64(xfer.assetAmount),
+        unitaryPrice: unitaryPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(),
+        bidUnitaryPrice: new arc4.UintN64(),
+      }),
+    )
+  }
+
+  @arc4.abimethod()
+  deposit(xfer: gtxn.AssetTransferTxn, nonce: arc4.UintN64) {
+    const key = new ListingKey({
+      owner: new arc4.Address(Txn.sender),
+      asset: new arc4.UintN64(xfer.xferAsset.id),
+      nonce: nonce,
+    })
+
+    assert(xfer.sender === Txn.sender)
+    assert(xfer.assetReceiver === Global.currentApplicationAddress)
+    assert(xfer.assetAmount > 0)
+
+    const existing = this.listings.get(key)
+    this.listings.set(
+      key,
+      new ListingValue({
+        bid: existing.bid,
+        bidUnitaryPrice: existing.bidUnitaryPrice,
+        bidder: existing.bidder,
+        unitaryPrice: existing.unitaryPrice,
+        deposited: new arc4.UintN64(existing.deposited.native + xfer.assetAmount),
+      }),
+    )
+  }
+
+  @arc4.abimethod()
+  setPrice(asset: Asset, nonce: arc4.UintN64, unitaryPrice: arc4.UintN64) {
+    const key = new ListingKey({
+      owner: new arc4.Address(Txn.sender),
+      asset: new arc4.UintN64(asset.id),
+      nonce: nonce,
+    })
+
+    const existing = this.listings.get(key)
+    this.listings.set(
+      key,
+      new ListingValue({
+        bid: existing.bid,
+        bidUnitaryPrice: existing.bidUnitaryPrice,
+        bidder: existing.bidder,
+        deposited: existing.deposited,
+        unitaryPrice: unitaryPrice,
+      }),
+    )
+  }
+
+  @arc4.abimethod()
+  buy(owner: arc4.Address, asset: Asset, nonce: arc4.UintN64, buyPay: gtxn.PaymentTxn, quantity: uint64) {
+    const key = new ListingKey({
+      owner: owner,
+      asset: new arc4.UintN64(asset.id),
+      nonce: nonce,
+    })
+
+    const listing = this.listings.get(key)
+
+    const amountToBePaid = this.quantityPrice(quantity, listing.unitaryPrice.native, asset.decimals)
+
+    assert(buyPay.sender === Txn.sender)
+    assert(buyPay.receiver.bytes === owner.bytes)
+    assert(buyPay.amount === amountToBePaid)
+
+    this.listings.set(
+      key,
+      new ListingValue({
+        bid: listing.bid,
+        bidUnitaryPrice: listing.bidUnitaryPrice,
+        bidder: listing.bidder,
+        unitaryPrice: listing.unitaryPrice,
+        deposited: new arc4.UintN64(listing.deposited.native - quantity),
+      }),
+    )
+
+    itxn
+      .assetTransfer({
+        xferAsset: asset,
+        assetReceiver: Txn.sender,
+        assetAmount: quantity,
+      })
+      .submit()
+  }
+
+  @arc4.abimethod()
+  withdraw(asset: Asset, nonce: arc4.UintN64) {
+    const key = new ListingKey({
+      owner: new arc4.Address(Txn.sender),
+      asset: new arc4.UintN64(asset.id),
+      nonce: nonce,
+    })
+
+    const listing = this.listings.get(key)
+    if (listing.bidder !== new arc4.Address()) {
+      const currentBidDeposit = this.quantityPrice(listing.bid.native, listing.bidUnitaryPrice.native, asset.decimals)
+      itxn.payment({ receiver: listing.bidder.native, amount: currentBidDeposit }).submit()
+    }
+
+    this.listings.delete(key)
+
+    itxn.payment({ receiver: Txn.sender, amount: this.listingsBoxMbr() }).submit()
+
+    itxn
+      .assetTransfer({
+        xferAsset: asset,
+        assetReceiver: Txn.sender,
+        assetAmount: listing.deposited.native,
+      })
+      .submit()
+  }
+
+  @arc4.abimethod()
+  bid(owner: arc4.Address, asset: Asset, nonce: arc4.UintN64, bidPay: gtxn.PaymentTxn, quantity: arc4.UintN64, unitaryPrice: arc4.UintN64) {
+    const key = new ListingKey({ owner, asset: new arc4.UintN64(asset.id), nonce })
+
+    const listing = this.listings.get(key)
+    if (listing.bidder !== new arc4.Address()) {
+      assert(unitaryPrice.native > listing.bidUnitaryPrice.native)
+
+      const currentBidAmount = this.quantityPrice(listing.bid.native, listing.bidUnitaryPrice.native, asset.decimals)
+
+      itxn.payment({ receiver: listing.bidder.native, amount: currentBidAmount }).submit()
+    }
+
+    const amountToBeBid = this.quantityPrice(quantity.native, unitaryPrice.native, asset.decimals)
+
+    assert(bidPay.sender === Txn.sender)
+    assert(bidPay.receiver === Global.currentApplicationAddress)
+    assert(bidPay.amount === amountToBeBid)
+
+    this.listings.set(
+      key,
+      new ListingValue({
+        deposited: listing.deposited,
+        unitaryPrice: listing.unitaryPrice,
+        bidder: new arc4.Address(Txn.sender),
+        bid: quantity,
+        bidUnitaryPrice: unitaryPrice,
+      }),
+    )
+  }
+
+  @arc4.abimethod()
+  acceptBid(asset: Asset, nonce: arc4.UintN64) {
+    const key = new ListingKey({ owner: new arc4.Address(Txn.sender), asset: new arc4.UintN64(asset.id), nonce })
+
+    const listing = this.listings.get(key)
+    assert(listing.bidder !== new arc4.Address())
+
+    const minQuantity = listing.deposited.native < listing.bid.native ? listing.deposited.native : listing.bid.native
+
+    const bestBidAmount = this.quantityPrice(minQuantity, listing.bidUnitaryPrice.native, asset.decimals)
+
+    itxn.payment({ receiver: Txn.sender, amount: bestBidAmount }).submit()
+
+    itxn
+      .assetTransfer({
+        xferAsset: asset,
+        assetReceiver: listing.bidder.native,
+        assetAmount: minQuantity,
+      })
+      .submit()
+
+    this.listings.set(
+      key,
+      new ListingValue({
+        bidder: listing.bidder,
+        bidUnitaryPrice: listing.bidUnitaryPrice,
+        unitaryPrice: listing.unitaryPrice,
+        deposited: new arc4.UintN64(listing.deposited.native - minQuantity),
+        bid: new arc4.UintN64(listing.bid.native - minQuantity),
+      }),
+    )
+  }
+}

--- a/contracts/marketplace.spec.ts
+++ b/contracts/marketplace.spec.ts
@@ -1,0 +1,293 @@
+import { arc4, Bytes } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { interpretAsArc4 } from '@algorandfoundation/algorand-typescript/arc4'
+import { afterEach, describe, expect, test } from 'vitest'
+import DigitalMarketplace, { ListingKey, ListingValue } from './marketplace.algo'
+
+const TEST_DECIMALS = 6
+
+describe('DigitalMarketplace', () => {
+  const ctx = new TestExecutionContext()
+
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  test('first deposit', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testApp = ctx.ledger.getApplicationForContract(contract)
+
+    // Act
+    contract.firstDeposit(
+      ctx.any.txn.payment({ receiver: testApp.address, amount: 50500 }),
+      ctx.any.txn.assetTransfer({
+        xferAsset: testAsset,
+        assetReceiver: testApp.address,
+        assetAmount: 10,
+      }),
+      ctx.any.arc4.uintN64(),
+      testNonce,
+    )
+
+    // Assert
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    const listingValue = interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(listingValue.deposited.native).toEqual(10)
+  })
+
+  test('deposit', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testApp = ctx.ledger.getApplicationForContract(contract)
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: new arc4.UintN64(10),
+        unitaryPrice: new arc4.UintN64(10),
+        bidder: new arc4.Address(ctx.defaultSender),
+        bid: new arc4.UintN64(10),
+        bidUnitaryPrice: new arc4.UintN64(10),
+      }),
+    )
+
+    // Act
+    contract.deposit(
+      ctx.any.txn.assetTransfer({
+        xferAsset: testAsset,
+        assetReceiver: testApp.address,
+        assetAmount: 10,
+      }),
+      testNonce,
+    )
+
+    // Assert
+    expect(ctx.ledger.boxExists(contract, Bytes('listings').concat(listingKey.bytes)))
+  })
+
+  test('setPrice', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const testUnitaryPrice = ctx.any.arc4.uintN64()
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: new arc4.UintN64(10),
+        unitaryPrice: new arc4.UintN64(10),
+        bidder: new arc4.Address(ctx.defaultSender),
+        bid: new arc4.UintN64(10),
+        bidUnitaryPrice: new arc4.UintN64(10),
+      }),
+    )
+
+    //  Act
+    contract.setPrice(testAsset, testNonce, testUnitaryPrice)
+
+    // Assert
+    const updatedListing = interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(updatedListing.unitaryPrice.native).toEqual(testUnitaryPrice.native)
+  })
+
+  test('buy', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const testOwner = new arc4.Address(ctx.defaultSender)
+    const testUnitaryPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const initialDeposit = ctx.any.arc4.uintN64()
+    const testBuyQuantity = ctx.any.arc4.uintN64(0, 1000000n)
+
+    const listingKey = new ListingKey({ owner: testOwner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: testUnitaryPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    // Act
+    contract.buy(
+      testOwner,
+      testAsset,
+      testNonce,
+      ctx.any.txn.payment({
+        receiver: ctx.defaultSender,
+        amount: contract.quantityPrice(testBuyQuantity.native, testUnitaryPrice.native, testAsset.decimals),
+      }),
+      testBuyQuantity.native,
+    )
+
+    // Assert
+    const updatedListing = interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(updatedListing.deposited.native).toEqual(initialDeposit.native - testBuyQuantity.native)
+    expect(ctx.txn.lastGroup.getItxnGroup(0).getAssetTransferInnerTxn(0).assetReceiver).toEqual(ctx.defaultSender)
+  })
+
+  test('withdraw', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testOwner = new arc4.Address(ctx.defaultSender)
+    const initialDeposit = ctx.any.arc4.uintN64(1)
+    const testUnitaryPrice = ctx.any.arc4.uintN64()
+
+    const listingsBoxMbr = contract.listingsBoxMbr()
+
+    const listingKey = new ListingKey({ owner: testOwner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: testUnitaryPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    //  Act
+    contract.withdraw(testAsset, testNonce)
+
+    // Assert
+    expect(ctx.ledger.boxExists(contract, Bytes('listings').concat(listingKey.bytes))).toEqual(false)
+    expect(ctx.txn.lastGroup.itxnGroups.length).toEqual(2)
+
+    const paymentTxn = ctx.txn.lastGroup.getItxnGroup(0).getPaymentInnerTxn(0)
+    expect(paymentTxn.receiver).toEqual(testOwner.native)
+    expect(paymentTxn.amount).toEqual(listingsBoxMbr)
+
+    const assetTransferTxn = ctx.txn.lastGroup.getItxnGroup(1).getAssetTransferInnerTxn(0)
+    expect(assetTransferTxn.xferAsset).toEqual(testAsset)
+    expect(assetTransferTxn.assetReceiver).toEqual(testOwner.native)
+    expect(assetTransferTxn.assetAmount).toEqual(initialDeposit.native)
+  })
+
+  test('bid', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const app = ctx.ledger.getApplicationForContract(contract)
+    const owner = new arc4.Address(ctx.defaultSender)
+    const initialPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const initialDeposit = ctx.any.arc4.uintN64(0, 1000000n)
+
+    const listingKey = new ListingKey({ owner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: initialPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    const bidder = ctx.any.account()
+    const bidQuantity = ctx.any.arc4.uintN64(0, BigInt(initialDeposit.native))
+    const bidPrice = ctx.any.arc4.uintN64(initialPrice.native + 1, 10000000n)
+    const bidAmount = contract.quantityPrice(bidQuantity.native, bidPrice.native, testAsset.decimals)
+
+    // Act
+    ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: app, sender: bidder })]).execute(() => {
+      contract.bid(
+        owner,
+        testAsset,
+        testNonce,
+        ctx.any.txn.payment({
+          sender: bidder,
+          receiver: app.address,
+          amount: bidAmount,
+        }),
+        bidQuantity,
+        bidPrice,
+      )
+    })
+
+    // Assert
+    const updatedListing = contract.listings.get(listingKey)
+    expect(updatedListing.bidder.native).toEqual(bidder)
+    expect(updatedListing.bid.native).toEqual(bidQuantity.native)
+    expect(updatedListing.bidUnitaryPrice.native).toEqual(bidPrice.native)
+  })
+
+  test('acceptBid', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const owner = ctx.defaultSender
+    const initialDeposit = ctx.any.arc4.uintN64(1, 10000000n)
+    const bidQuantity = ctx.any.arc4.uintN64(0, BigInt(initialDeposit.native))
+    const bidPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const bidder = ctx.any.account()
+
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(owner),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: ctx.any.arc4.uintN64(),
+        bidder: new arc4.Address(bidder),
+        bid: bidQuantity,
+        bidUnitaryPrice: bidPrice,
+      }),
+    )
+
+    const minQuantity = initialDeposit.native < bidQuantity.native ? initialDeposit.native : bidQuantity.native
+    const expectedPayment = contract.quantityPrice(minQuantity, bidPrice.native, testAsset.decimals)
+
+    // Act
+    contract.acceptBid(testAsset, testNonce)
+
+    // Assert
+    const updatedListing = contract.listings.get(listingKey)
+    expect(updatedListing.deposited.native).toEqual(initialDeposit.native - minQuantity)
+
+    expect(ctx.txn.lastGroup.itxnGroups.length).toEqual(2)
+
+    const paymentTxn = ctx.txn.lastGroup.getItxnGroup(0).getPaymentInnerTxn(0)
+    expect(paymentTxn.receiver).toEqual(owner)
+    expect(paymentTxn.amount).toEqual(expectedPayment)
+
+    const assetTransferTxn = ctx.txn.lastGroup.getItxnGroup(1).getAssetTransferInnerTxn(0)
+    expect(assetTransferTxn.xferAsset).toEqual(testAsset)
+    expect(assetTransferTxn.assetReceiver).toEqual(bidder)
+    expect(assetTransferTxn.assetAmount).toEqual(minQuantity)
+  })
+})

--- a/contracts/marketplace.test.ts
+++ b/contracts/marketplace.test.ts
@@ -1,0 +1,292 @@
+import { arc4, Bytes } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, test } from '@jest/globals'
+import DigitalMarketplace, { ListingKey, ListingValue } from './marketplace.algo'
+
+const TEST_DECIMALS = 6
+
+describe('DigitalMarketplace', () => {
+  const ctx = new TestExecutionContext()
+
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  test('first deposit', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testApp = ctx.ledger.getApplicationForContract(contract)
+
+    // Act
+    contract.firstDeposit(
+      ctx.any.txn.payment({ receiver: testApp.address, amount: 50500 }),
+      ctx.any.txn.assetTransfer({
+        xferAsset: testAsset,
+        assetReceiver: testApp.address,
+        assetAmount: 10,
+      }),
+      ctx.any.arc4.uintN64(),
+      testNonce,
+    )
+
+    // Assert
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    const listingValue = arc4.interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(listingValue.deposited.native).toEqual(10)
+  })
+
+  test('deposit', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testApp = ctx.ledger.getApplicationForContract(contract)
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: new arc4.UintN64(10),
+        unitaryPrice: new arc4.UintN64(10),
+        bidder: new arc4.Address(ctx.defaultSender),
+        bid: new arc4.UintN64(10),
+        bidUnitaryPrice: new arc4.UintN64(10),
+      }),
+    )
+
+    // Act
+    contract.deposit(
+      ctx.any.txn.assetTransfer({
+        xferAsset: testAsset,
+        assetReceiver: testApp.address,
+        assetAmount: 10,
+      }),
+      testNonce,
+    )
+
+    // Assert
+    expect(ctx.ledger.boxExists(contract, Bytes('listings').concat(listingKey.bytes)))
+  })
+
+  test('setPrice', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const testUnitaryPrice = ctx.any.arc4.uintN64()
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(ctx.defaultSender),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: new arc4.UintN64(10),
+        unitaryPrice: new arc4.UintN64(10),
+        bidder: new arc4.Address(ctx.defaultSender),
+        bid: new arc4.UintN64(10),
+        bidUnitaryPrice: new arc4.UintN64(10),
+      }),
+    )
+
+    //  Act
+    contract.setPrice(testAsset, testNonce, testUnitaryPrice)
+
+    // Assert
+    const updatedListing = arc4.interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(updatedListing.unitaryPrice.native).toEqual(testUnitaryPrice.native)
+  })
+
+  test('buy', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const testOwner = new arc4.Address(ctx.defaultSender)
+    const testUnitaryPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const initialDeposit = ctx.any.arc4.uintN64()
+    const testBuyQuantity = ctx.any.arc4.uintN64(0, 1000000n)
+
+    const listingKey = new ListingKey({ owner: testOwner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: testUnitaryPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    // Act
+    contract.buy(
+      testOwner,
+      testAsset,
+      testNonce,
+      ctx.any.txn.payment({
+        receiver: ctx.defaultSender,
+        amount: contract.quantityPrice(testBuyQuantity.native, testUnitaryPrice.native, testAsset.decimals),
+      }),
+      testBuyQuantity.native,
+    )
+
+    // Assert
+    const updatedListing = arc4.interpretAsArc4<ListingValue>(Bytes(ctx.ledger.getBox(contract, Bytes('listings').concat(listingKey.bytes))))
+    expect(updatedListing.deposited.native).toEqual(initialDeposit.native - testBuyQuantity.native)
+    expect(ctx.txn.lastGroup.getItxnGroup(0).getAssetTransferInnerTxn(0).assetReceiver).toEqual(ctx.defaultSender)
+  })
+
+  test('withdraw', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const testOwner = new arc4.Address(ctx.defaultSender)
+    const initialDeposit = ctx.any.arc4.uintN64(1)
+    const testUnitaryPrice = ctx.any.arc4.uintN64()
+
+    const listingsBoxMbr = contract.listingsBoxMbr()
+
+    const listingKey = new ListingKey({ owner: testOwner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: testUnitaryPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    //  Act
+    contract.withdraw(testAsset, testNonce)
+
+    // Assert
+    expect(ctx.ledger.boxExists(contract, Bytes('listings').concat(listingKey.bytes))).toEqual(false)
+    expect(ctx.txn.lastGroup.itxnGroups.length).toEqual(2)
+
+    const paymentTxn = ctx.txn.lastGroup.getItxnGroup(0).getPaymentInnerTxn(0)
+    expect(paymentTxn.receiver).toEqual(testOwner.native)
+    expect(paymentTxn.amount).toEqual(listingsBoxMbr)
+
+    const assetTransferTxn = ctx.txn.lastGroup.getItxnGroup(1).getAssetTransferInnerTxn(0)
+    expect(assetTransferTxn.xferAsset).toEqual(testAsset)
+    expect(assetTransferTxn.assetReceiver).toEqual(testOwner.native)
+    expect(assetTransferTxn.assetAmount).toEqual(initialDeposit.native)
+  })
+
+  test('bid', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+
+    // Arrange
+    const app = ctx.ledger.getApplicationForContract(contract)
+    const owner = new arc4.Address(ctx.defaultSender)
+    const initialPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const initialDeposit = ctx.any.arc4.uintN64(0, 1000000n)
+
+    const listingKey = new ListingKey({ owner, asset: new arc4.UintN64(testAsset.id), nonce: testNonce })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: initialPrice,
+        bidder: new arc4.Address(),
+        bid: new arc4.UintN64(0),
+        bidUnitaryPrice: new arc4.UintN64(0),
+      }),
+    )
+
+    const bidder = ctx.any.account()
+    const bidQuantity = ctx.any.arc4.uintN64(0, BigInt(initialDeposit.native))
+    const bidPrice = ctx.any.arc4.uintN64(initialPrice.native + 1, 10000000n)
+    const bidAmount = contract.quantityPrice(bidQuantity.native, bidPrice.native, testAsset.decimals)
+
+    // Act
+    ctx.txn.createScope([ctx.any.txn.applicationCall({ appId: app, sender: bidder })]).execute(() => {
+      contract.bid(
+        owner,
+        testAsset,
+        testNonce,
+        ctx.any.txn.payment({
+          sender: bidder,
+          receiver: app.address,
+          amount: bidAmount,
+        }),
+        bidQuantity,
+        bidPrice,
+      )
+    })
+
+    // Assert
+    const updatedListing = contract.listings.get(listingKey)
+    expect(updatedListing.bidder.native).toEqual(bidder)
+    expect(updatedListing.bid.native).toEqual(bidQuantity.native)
+    expect(updatedListing.bidUnitaryPrice.native).toEqual(bidPrice.native)
+  })
+
+  test('acceptBid', () => {
+    const contract = ctx.contract.create(DigitalMarketplace)
+    const testAsset = ctx.any.asset({ decimals: TEST_DECIMALS })
+    const testNonce = ctx.any.arc4.uintN64()
+    // Arrange
+    const owner = ctx.defaultSender
+    const initialDeposit = ctx.any.arc4.uintN64(1, 10000000n)
+    const bidQuantity = ctx.any.arc4.uintN64(0, BigInt(initialDeposit.native))
+    const bidPrice = ctx.any.arc4.uintN64(0, 10000000n)
+    const bidder = ctx.any.account()
+
+    const listingKey = new ListingKey({
+      owner: new arc4.Address(owner),
+      asset: new arc4.UintN64(testAsset.id),
+      nonce: testNonce,
+    })
+    contract.listings.set(
+      listingKey,
+      new ListingValue({
+        deposited: initialDeposit,
+        unitaryPrice: ctx.any.arc4.uintN64(),
+        bidder: new arc4.Address(bidder),
+        bid: bidQuantity,
+        bidUnitaryPrice: bidPrice,
+      }),
+    )
+
+    const minQuantity = initialDeposit.native < bidQuantity.native ? initialDeposit.native : bidQuantity.native
+    const expectedPayment = contract.quantityPrice(minQuantity, bidPrice.native, testAsset.decimals)
+
+    // Act
+    contract.acceptBid(testAsset, testNonce)
+
+    // Assert
+    const updatedListing = contract.listings.get(listingKey)
+    expect(updatedListing.deposited.native).toEqual(initialDeposit.native - minQuantity)
+
+    expect(ctx.txn.lastGroup.itxnGroups.length).toEqual(2)
+
+    const paymentTxn = ctx.txn.lastGroup.getItxnGroup(0).getPaymentInnerTxn(0)
+    expect(paymentTxn.receiver).toEqual(owner)
+    expect(paymentTxn.amount).toEqual(expectedPayment)
+
+    const assetTransferTxn = ctx.txn.lastGroup.getItxnGroup(1).getAssetTransferInnerTxn(0)
+    expect(assetTransferTxn.xferAsset).toEqual(testAsset)
+    expect(assetTransferTxn.assetReceiver).toEqual(bidder)
+    expect(assetTransferTxn.assetAmount).toEqual(minQuantity)
+  })
+})

--- a/contracts/proof-of-attendance.algo.ts
+++ b/contracts/proof-of-attendance.algo.ts
@@ -1,0 +1,217 @@
+import type { Account, Asset, bytes, gtxn, uint64 } from '@algorandfoundation/algorand-typescript'
+import {
+  arc4,
+  assert,
+  Box,
+  BoxMap,
+  BoxRef,
+  Bytes,
+  ensureBudget,
+  Global,
+  GlobalState,
+  itxn,
+  op,
+  OpUpFeeSource,
+  Txn,
+  Uint64,
+} from '@algorandfoundation/algorand-typescript'
+
+export default class ProofOfAttendance extends arc4.Contract {
+  maxAttendees = GlobalState({ initialValue: Uint64(30) })
+  assetUrl = GlobalState({ initialValue: 'ipfs://QmW5vERkgeJJtSY1YQdcWU6gsHCZCyLFtM1oT9uyy2WGm8' })
+  totalAttendees = GlobalState({ initialValue: Uint64(0) })
+  boxMap = BoxMap<bytes, uint64>({ keyPrefix: 'boxMap' })
+
+  @arc4.abimethod({ onCreate: 'require' })
+  init(maxAttendees: uint64) {
+    assert(Txn.sender === Global.creatorAddress, 'Only creator can initialize')
+    this.maxAttendees.value = maxAttendees
+  }
+
+  @arc4.abimethod()
+  confirmAttendance() {
+    assert(this.totalAttendees.value < this.maxAttendees.value, 'Max attendees reached')
+
+    const mintedAsset = this.mintPoa(Txn.sender)
+    this.totalAttendees.value += 1
+
+    const [_id, hasClaimed] = op.Box.get(Txn.sender.bytes)
+    assert(!hasClaimed, 'Already claimed POA')
+
+    op.Box.put(Txn.sender.bytes, op.itob(mintedAsset.id))
+  }
+
+  @arc4.abimethod()
+  confirmAttendanceWithBox() {
+    assert(this.totalAttendees.value < this.maxAttendees.value, 'Max attendees reached')
+
+    const mintedAsset = this.mintPoa(Txn.sender)
+    this.totalAttendees.value += 1
+
+    const box = Box<uint64>({ key: Txn.sender.bytes })
+    const hasClaimed = box.exists
+    assert(!hasClaimed, 'Already claimed POA')
+
+    box.value = mintedAsset.id
+  }
+
+  @arc4.abimethod()
+  confirmAttendanceWithBoxRef() {
+    assert(this.totalAttendees.value < this.maxAttendees.value, 'Max attendees reached')
+
+    const mintedAsset = this.mintPoa(Txn.sender)
+    this.totalAttendees.value += 1
+
+    const boxRef = BoxRef({ key: Txn.sender.bytes })
+    const hasClaimed = boxRef.exists
+    assert(!hasClaimed, 'Already claimed POA')
+
+    boxRef.put(op.itob(mintedAsset.id))
+  }
+
+  @arc4.abimethod()
+  confirmAttendanceWithBoxMap() {
+    assert(this.totalAttendees.value < this.maxAttendees.value, 'Max attendees reached')
+
+    const mintedAsset = this.mintPoa(Txn.sender)
+    this.totalAttendees.value += 1
+
+    const hasClaimed = this.boxMap.has(Txn.sender.bytes)
+    assert(!hasClaimed, 'Already claimed POA')
+
+    this.boxMap.set(Txn.sender.bytes, mintedAsset.id)
+  }
+  @arc4.abimethod({ readonly: true })
+  getPoaId(): uint64 {
+    const [poaId, exists] = op.Box.get(Txn.sender.bytes)
+    assert(exists, 'POA not found')
+    return op.btoi(poaId)
+  }
+
+  @arc4.abimethod({ readonly: true })
+  getPoaIdWithBox(): uint64 {
+    const box = Box<uint64>({ key: Txn.sender.bytes })
+    const [poaId, exists] = box.maybe()
+    assert(exists, 'POA not found')
+    return poaId
+  }
+
+  @arc4.abimethod({ readonly: true })
+  getPoaIdWithBoxRef(): uint64 {
+    const boxRef = BoxRef({ key: Txn.sender.bytes })
+    const [poaId, exists] = boxRef.maybe()
+    assert(exists, 'POA not found')
+    return op.btoi(poaId)
+  }
+
+  @arc4.abimethod({ readonly: true })
+  getPoaIdWithBoxMap(): uint64 {
+    const [poaId, exists] = this.boxMap.maybe(Txn.sender.bytes)
+    assert(exists, 'POA not found')
+    return poaId
+  }
+
+  @arc4.abimethod()
+  claimPoa(optInTxn: gtxn.AssetTransferTxn) {
+    const [poaId, exists] = op.Box.get(Txn.sender.bytes)
+    assert(exists, 'POA not found, attendance validation failed!')
+    assert(optInTxn.xferAsset.id === op.btoi(poaId), 'POA ID mismatch')
+    assert(optInTxn.fee === 0, 'We got you covered for free!')
+    assert(optInTxn.assetAmount === 0)
+    assert(
+      optInTxn.sender === optInTxn.assetReceiver && optInTxn.assetReceiver === Txn.sender,
+      'Opt-in transaction sender and receiver must be the same',
+    )
+    assert(
+      optInTxn.assetCloseTo === optInTxn.rekeyTo && optInTxn.rekeyTo === Global.zeroAddress,
+      'Opt-in transaction close to must be zero address',
+    )
+
+    this.sendPoa(Txn.sender, optInTxn.xferAsset)
+  }
+
+  @arc4.abimethod()
+  claimPoaWithBox(optInTxn: gtxn.AssetTransferTxn) {
+    const box = Box<uint64>({ key: Txn.sender.bytes })
+    const [poaId, exists] = box.maybe()
+    assert(exists, 'POA not found, attendance validation failed!')
+    assert(optInTxn.xferAsset.id === poaId, 'POA ID mismatch')
+    assert(optInTxn.fee === 0, 'We got you covered for free!')
+    assert(optInTxn.assetAmount === 0)
+    assert(
+      optInTxn.sender === optInTxn.assetReceiver && optInTxn.assetReceiver === Txn.sender,
+      'Opt-in transaction sender and receiver must be the same',
+    )
+    assert(
+      optInTxn.assetCloseTo === optInTxn.rekeyTo && optInTxn.rekeyTo === Global.zeroAddress,
+      'Opt-in transaction close to must be zero address',
+    )
+
+    this.sendPoa(Txn.sender, optInTxn.xferAsset)
+  }
+
+  @arc4.abimethod()
+  claimPoaWithBoxRef(optInTxn: gtxn.AssetTransferTxn) {
+    const boxRef = BoxRef({ key: Txn.sender.bytes })
+    const [poaId, exists] = boxRef.maybe()
+    assert(exists, 'POA not found, attendance validation failed!')
+    assert(optInTxn.xferAsset.id === op.btoi(poaId), 'POA ID mismatch')
+    assert(optInTxn.fee === 0, 'We got you covered for free!')
+    assert(optInTxn.assetAmount === 0)
+    assert(
+      optInTxn.sender === optInTxn.assetReceiver && optInTxn.assetReceiver === Txn.sender,
+      'Opt-in transaction sender and receiver must be the same',
+    )
+    assert(
+      optInTxn.assetCloseTo === optInTxn.rekeyTo && optInTxn.rekeyTo === Global.zeroAddress,
+      'Opt-in transaction close to must be zero address',
+    )
+
+    this.sendPoa(Txn.sender, optInTxn.xferAsset)
+  }
+
+  @arc4.abimethod()
+  claimPoaWithBoxMap(optInTxn: gtxn.AssetTransferTxn) {
+    const [poaId, exists] = this.boxMap.maybe(Txn.sender.bytes)
+    assert(exists, 'POA not found, attendance validation failed!')
+    assert(optInTxn.xferAsset.id === poaId, 'POA ID mismatch')
+    assert(optInTxn.fee === 0, 'We got you covered for free!')
+    assert(optInTxn.assetAmount === 0)
+    assert(
+      optInTxn.sender === optInTxn.assetReceiver && optInTxn.assetReceiver === Txn.sender,
+      'Opt-in transaction sender and receiver must be the same',
+    )
+    assert(
+      optInTxn.assetCloseTo === optInTxn.rekeyTo && optInTxn.rekeyTo === Global.zeroAddress,
+      'Opt-in transaction close to must be zero address',
+    )
+
+    this.sendPoa(Txn.sender, optInTxn.xferAsset)
+  }
+
+  private mintPoa(claimer: Account): Asset {
+    ensureBudget(10000, OpUpFeeSource.AppAccount)
+    const assetName = Bytes('AlgoKit POA #').concat(op.itob(this.totalAttendees.value))
+    return itxn
+      .assetConfig({
+        assetName: assetName,
+        unitName: 'POA',
+        total: 1,
+        decimals: 0,
+        url: this.assetUrl.value,
+        manager: claimer,
+      })
+      .submit().createdAsset
+  }
+
+  private sendPoa(receiver: Account, asset: Asset) {
+    itxn
+      .assetTransfer({
+        xferAsset: asset,
+        sender: Global.currentApplicationAddress,
+        assetReceiver: receiver,
+        assetAmount: 1,
+      })
+      .submit()
+  }
+}

--- a/contracts/proof-of-attendance.spec.ts
+++ b/contracts/proof-of-attendance.spec.ts
@@ -1,0 +1,81 @@
+import { Account, Bytes, op } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, it, test } from 'vitest'
+import ProofOfAttendance from './proof-of-attendance.algo'
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type DeliberateAny = any
+const ZERO_ADDRESS = Bytes.fromBase32('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+
+describe('ProofOfAttendance', () => {
+  const ctx = new TestExecutionContext()
+
+  const getContract = () => {
+    const contract = ctx.contract.create(ProofOfAttendance)
+    contract.init(ctx.any.uint64(1, 100))
+    return contract
+  }
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  it('should be able to init', () => {
+    // Arrange
+    const contract = ctx.contract.create(ProofOfAttendance)
+    const maxAttendees = ctx.any.uint64(1, 100)
+
+    // Act
+    contract.init(maxAttendees)
+
+    // Assert
+    expect(contract.maxAttendees.value).toEqual(maxAttendees)
+  })
+
+  test.each([
+    ['confirmAttendance', Bytes('')],
+    ['confirmAttendanceWithBox', Bytes('')],
+    ['confirmAttendanceWithBoxRef', Bytes('')],
+    ['confirmAttendanceWithBoxMap', Bytes('boxMap')],
+  ])('%s', (confirmAttendance, keyPrefix) => {
+    // Arrange
+    const contract = getContract()
+
+    // Act
+    const confirm = (contract as DeliberateAny)[confirmAttendance]
+    confirm()
+
+    // Assert
+    const boxContent = ctx.ledger.getBox(contract, keyPrefix.concat(ctx.defaultSender.bytes))
+    expect(boxContent).toEqual(op.itob(1001))
+  })
+  test.each([
+    ['claimPoa', Bytes('')],
+    ['claimPoaWithBox', Bytes('')],
+    ['claimPoaWithBoxRef', Bytes('')],
+    ['claimPoaWithBoxMap', Bytes('boxMap')],
+  ])('%s', (claimPoa, keyPrefix) => {
+    // Arrange
+    const contract = getContract()
+
+    const dummyPoa = ctx.any.asset()
+    const optInTxn = ctx.any.txn.assetTransfer({
+      sender: ctx.defaultSender,
+      assetReceiver: ctx.defaultSender,
+      assetCloseTo: Account(ZERO_ADDRESS),
+      rekeyTo: Account(ZERO_ADDRESS),
+      xferAsset: dummyPoa,
+      fee: 0,
+      assetAmount: 0,
+    })
+    ctx.ledger.setBox(contract, keyPrefix.concat(ctx.defaultSender.bytes), op.itob(dummyPoa.id))
+
+    // Act
+    const claim = (contract as DeliberateAny)[claimPoa]
+    claim(optInTxn)
+
+    // Assert
+    const axferItxn = ctx.txn.lastGroup.getItxnGroup().getAssetTransferInnerTxn(0)
+    expect(axferItxn.assetReceiver).toEqual(ctx.defaultSender)
+    expect(axferItxn.assetAmount).toEqual(1)
+  })
+})

--- a/contracts/proof-of-attendance.test.ts
+++ b/contracts/proof-of-attendance.test.ts
@@ -1,0 +1,81 @@
+import { Account, Bytes, op } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, it, test } from '@jest/globals'
+import ProofOfAttendance from './proof-of-attendance.algo'
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type DeliberateAny = any
+const ZERO_ADDRESS = Bytes.fromBase32('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+
+describe('ProofOfAttendance', () => {
+  const ctx = new TestExecutionContext()
+
+  const getContract = () => {
+    const contract = ctx.contract.create(ProofOfAttendance)
+    contract.init(ctx.any.uint64(1, 100))
+    return contract
+  }
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  it('should be able to init', () => {
+    // Arrange
+    const contract = ctx.contract.create(ProofOfAttendance)
+    const maxAttendees = ctx.any.uint64(1, 100)
+
+    // Act
+    contract.init(maxAttendees)
+
+    // Assert
+    expect(contract.maxAttendees.value).toEqual(maxAttendees)
+  })
+
+  test.each([
+    ['confirmAttendance', Bytes('')],
+    ['confirmAttendanceWithBox', Bytes('')],
+    ['confirmAttendanceWithBoxRef', Bytes('')],
+    ['confirmAttendanceWithBoxMap', Bytes('boxMap')],
+  ])('%s', (confirmAttendance, keyPrefix) => {
+    // Arrange
+    const contract = getContract()
+
+    // Act
+    const confirm = (contract as DeliberateAny)[confirmAttendance]
+    confirm()
+
+    // Assert
+    const boxContent = ctx.ledger.getBox(contract, keyPrefix.concat(ctx.defaultSender.bytes))
+    expect(boxContent).toEqual(op.itob(1001))
+  })
+  test.each([
+    ['claimPoa', Bytes('')],
+    ['claimPoaWithBox', Bytes('')],
+    ['claimPoaWithBoxRef', Bytes('')],
+    ['claimPoaWithBoxMap', Bytes('boxMap')],
+  ])('%s', (claimPoa, keyPrefix) => {
+    // Arrange
+    const contract = getContract()
+
+    const dummyPoa = ctx.any.asset()
+    const optInTxn = ctx.any.txn.assetTransfer({
+      sender: ctx.defaultSender,
+      assetReceiver: ctx.defaultSender,
+      assetCloseTo: Account(ZERO_ADDRESS),
+      rekeyTo: Account(ZERO_ADDRESS),
+      xferAsset: dummyPoa,
+      fee: 0,
+      assetAmount: 0,
+    })
+    ctx.ledger.setBox(contract, keyPrefix.concat(ctx.defaultSender.bytes), op.itob(dummyPoa.id))
+
+    // Act
+    const claim = (contract as DeliberateAny)[claimPoa]
+    claim(optInTxn)
+
+    // Assert
+    const axferItxn = ctx.txn.lastGroup.getItxnGroup().getAssetTransferInnerTxn(0)
+    expect(axferItxn.assetReceiver).toEqual(ctx.defaultSender)
+    expect(axferItxn.assetAmount).toEqual(1)
+  })
+})

--- a/contracts/voting.algo.ts
+++ b/contracts/voting.algo.ts
@@ -1,0 +1,36 @@
+import type { gtxn, uint64 } from '@algorandfoundation/algorand-typescript'
+import { arc4, assert, Bytes, GlobalState, LocalState, op, Txn, Uint64 } from '@algorandfoundation/algorand-typescript'
+
+export default class VotingContract extends arc4.Contract {
+  topic = GlobalState({ initialValue: Bytes('default_topic'), key: Bytes('topic') })
+  votes = GlobalState({ initialValue: Uint64(0), key: Bytes('votes') })
+  voted = LocalState<uint64>({ key: Bytes('voted') })
+
+  @arc4.abimethod()
+  public setTopic(topic: string): void {
+    this.topic.value = Bytes(topic)
+  }
+  @arc4.abimethod()
+  public vote(pay: gtxn.PaymentTxn): arc4.Bool {
+    assert(op.Global.groupSize === 2, 'Expected 2 transactions')
+    assert(pay.amount === 10_000, 'Incorrect payment amount')
+    assert(pay.sender === Txn.sender, 'Payment sender must match transaction sender')
+
+    if (this.voted(Txn.sender).hasValue) {
+      return new arc4.Bool(false) // Already voted
+    }
+
+    this.votes.value = this.votes.value + 1
+    this.voted(Txn.sender).value = 1
+    return new arc4.Bool(true)
+  }
+
+  @arc4.abimethod({ readonly: true })
+  public getVotes(): arc4.UintN64 {
+    return new arc4.UintN64(this.votes.value)
+  }
+
+  public clearStateProgram(): boolean {
+    return true
+  }
+}

--- a/contracts/voting.spec.ts
+++ b/contracts/voting.spec.ts
@@ -1,0 +1,45 @@
+import { Uint64 } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, test } from 'vitest'
+import VotingContract from './voting.algo'
+
+describe('Voting contract', () => {
+  const ctx = new TestExecutionContext()
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  test('vote function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    const voter = ctx.defaultSender
+    const payment = ctx.any.txn.payment({
+      sender: voter,
+      amount: 10_000,
+    })
+
+    const result = contract.vote(payment)
+    expect(result.native).toEqual(true)
+    expect(contract.votes.value).toEqual(1)
+    expect(contract.voted(voter).value).toEqual(1)
+  })
+
+  test('setTopic function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    const newTopic = ctx.any.string(10)
+    contract.setTopic(newTopic)
+    expect(contract.topic.value).toEqual(newTopic)
+  })
+
+  test('getVotes function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    contract.votes.value = Uint64(5)
+    const votes = contract.getVotes()
+    expect(votes.native).toEqual(5)
+  })
+})

--- a/contracts/voting.test.ts
+++ b/contracts/voting.test.ts
@@ -1,0 +1,45 @@
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, test } from '@jest/globals'
+import VotingContract from './voting.algo'
+import { Uint64 } from '@algorandfoundation/algorand-typescript'
+
+describe('Voting contract', () => {
+  const ctx = new TestExecutionContext()
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  test('vote function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    const voter = ctx.defaultSender
+    const payment = ctx.any.txn.payment({
+      sender: voter,
+      amount: 10_000,
+    })
+
+    const result = contract.vote(payment)
+    expect(result.native).toEqual(true)    
+    expect(contract.votes.value).toEqual(1)
+    expect(contract.voted(voter).value).toEqual(1)    
+  })
+
+  test('setTopic function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    const newTopic = ctx.any.string(10)
+    contract.setTopic(newTopic)
+    expect(contract.topic.value).toEqual(newTopic)
+  })
+
+  test('getVotes function', () => {
+    // Initialize the contract within the testing context
+    const contract = ctx.contract.create(VotingContract)
+
+    contract.votes.value = Uint64(5)
+    const votes = contract.getVotes()
+    expect(votes.native).toEqual(5)
+  })
+})

--- a/contracts/zk-whitelist.algo.ts
+++ b/contracts/zk-whitelist.algo.ts
@@ -1,0 +1,96 @@
+import type { uint64 } from '@algorandfoundation/algorand-typescript'
+import {
+  abimethod,
+  Account,
+  arc4,
+  assert,
+  BigUint,
+  Bytes,
+  ensureBudget,
+  Global,
+  GlobalState,
+  itxn,
+  LocalState,
+  op,
+  OpUpFeeSource,
+  TemplateVar,
+  Txn,
+  Uint64,
+} from '@algorandfoundation/algorand-typescript'
+
+const curveMod = BigUint(21888242871839275222246405745257275088548364400416034343698204186575808495617n)
+const verifierBudget = Uint64(145000)
+
+export default class ZkWhitelistContract extends arc4.Contract {
+  appName = GlobalState<arc4.Str>({})
+  whiteList = LocalState<boolean>()
+
+  @abimethod({ onCreate: 'require' })
+  create(name: arc4.Str) {
+    // Create the application
+    this.appName.value = name
+  }
+
+  @abimethod({ allowActions: ['UpdateApplication', 'DeleteApplication'] })
+  update() {
+    // Update the application if it is mutable (manager only)
+    assert(Global.creatorAddress === Txn.sender)
+  }
+
+  @abimethod({ allowActions: ['OptIn', 'CloseOut'] })
+  optInOrOut() {
+    // Opt in or out of the application
+    return
+  }
+
+  @abimethod()
+  addAddressToWhitelist(address: arc4.Address, proof: arc4.DynamicArray<arc4.Address>): arc4.Str {
+    /*
+    Add caller to the whitelist if the zk proof is valid.
+    On success, will return an empty string. Otherwise, will return an error
+    message.
+    */
+    ensureBudget(verifierBudget, OpUpFeeSource.GroupCredit)
+    // The verifier expects public inputs to be in the curve field, but an
+    // Algorand address might represent a number larger than the field
+    // modulus, so to be safe we take the address modulo the field modulus
+    const addressMod = arc4.interpretAsArc4<arc4.Address>(op.bzero(32).bitwiseOr(Bytes(BigUint(address.bytes) % curveMod)))
+    // Verify the proof by calling the deposit verifier app
+    const verified = this.verifyProof(TemplateVar<uint64>('VERIFIER_APP_ID'), proof, new arc4.DynamicArray(addressMod))
+    if (!verified.native) {
+      return new arc4.Str('Proof verification failed')
+    }
+    // if successful, add the sender to the whitelist by setting local state
+    const account = Account(address.bytes)
+    if (Txn.sender !== account) {
+      return new arc4.Str('Sender address does not match authorized address')
+    }
+    this.whiteList(account).value = true
+    return new arc4.Str('')
+  }
+
+  @abimethod()
+  isOnWhitelist(address: arc4.Address): arc4.Bool {
+    // Check if an address is on the whitelist
+    const account = address.native
+    const optedIn = op.appOptedIn(account, Global.currentApplicationId)
+    if (!optedIn) {
+      return new arc4.Bool(false)
+    }
+    const whitelisted = this.whiteList(account).value
+    return new arc4.Bool(whitelisted)
+  }
+
+  verifyProof(appId: uint64, proof: arc4.DynamicArray<arc4.Address>, publicInputs: arc4.DynamicArray<arc4.Address>): arc4.Bool {
+    // Verify a proof using the verifier app.
+    const verified = itxn
+      .applicationCall({
+        appId: appId,
+        fee: 0,
+        appArgs: [arc4.methodSelector('verify(byte[32][],byte[32][])bool'), proof.copy(), publicInputs.copy()],
+        onCompletion: arc4.OnCompleteAction.NoOp,
+      })
+      .submit().lastLog
+    return arc4.interpretAsArc4<arc4.Bool>(verified, 'log')
+  }
+}

--- a/contracts/zk-whitelist.spec.ts
+++ b/contracts/zk-whitelist.spec.ts
@@ -1,0 +1,80 @@
+import { arc4, Bytes, Uint64 } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, it } from 'vitest'
+import ZkWhitelistContract from './zk-whitelist.algo'
+
+const ABI_RETURN_VALUE_LOG_PREFIX = Bytes.fromHex('151F7C75')
+
+describe('ZK Whitelist', () => {
+  const ctx = new TestExecutionContext()
+
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  it('should be able to add address to whitelist', () => {    
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const address = new arc4.Address(ctx.defaultSender)
+    const proof = new arc4.DynamicArray<arc4.Address>(new arc4.Address(Bytes(new Uint8Array(Array(32).fill(0)))))
+
+    const dummyVerifierApp = ctx.any.application({ appLogs: [ABI_RETURN_VALUE_LOG_PREFIX.concat(Bytes.fromHex('80'))] })
+    ctx.setTemplateVar('VERIFIER_APP_ID', dummyVerifierApp.id)
+
+    // Act
+    const result = contract.addAddressToWhitelist(address, proof)
+
+    // Assert
+    expect(result.native).toEqual('')
+    expect(contract.whiteList(ctx.defaultSender).value).toEqual(true)
+  })
+
+  it('returns error message if proof verification fails', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const address = ctx.any.arc4.address()
+    const proof = new arc4.DynamicArray<arc4.Address>(new arc4.Address(Bytes(new Uint8Array(Array(32).fill(0)))))
+    const dummyVerifierApp = ctx.any.application({ appLogs: [ABI_RETURN_VALUE_LOG_PREFIX.concat(Bytes(''))] })
+    ctx.setTemplateVar('VERIFIER_APP_ID', dummyVerifierApp.id)
+
+    // Act
+    const result = contract.addAddressToWhitelist(address, proof)
+
+    // Assert
+    expect(result.native).toEqual('Proof verification failed')
+  })
+
+  it('returns true if address is already in whitelist', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const dummyAccount = ctx.any.account({ optedApplications: [ctx.ledger.getApplicationForContract(contract)] })
+    contract.whiteList(dummyAccount).value = true
+
+    // Act
+    const result = contract.isOnWhitelist(new arc4.Address(dummyAccount))
+
+    // Assert
+    expect(result.native).toBe(true)
+  })
+
+  it('returns false if address is not in whitelist', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const dummyAccount = ctx.any.account({ optedApplications: [ctx.ledger.getApplicationForContract(contract)] })
+    contract.whiteList(dummyAccount).value = false
+
+    // Act
+    const result = contract.isOnWhitelist(new arc4.Address(dummyAccount))
+
+    // Assert
+    expect(result.native).toBe(false)
+  })
+})

--- a/contracts/zk-whitelist.test.ts
+++ b/contracts/zk-whitelist.test.ts
@@ -1,0 +1,80 @@
+import { arc4, Bytes, Uint64 } from '@algorandfoundation/algorand-typescript'
+import { TestExecutionContext } from '@algorandfoundation/algorand-typescript-testing'
+import { afterEach, describe, expect, it } from '@jest/globals'
+import ZkWhitelistContract from './zk-whitelist.algo'
+
+const ABI_RETURN_VALUE_LOG_PREFIX = Bytes.fromHex('151F7C75')
+
+describe('ZK Whitelist', () => {
+  const ctx = new TestExecutionContext()
+
+  afterEach(() => {
+    ctx.reset()
+  })
+
+  it('should be able to add address to whitelist', () => {    
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const address = new arc4.Address(ctx.defaultSender)
+    const proof = new arc4.DynamicArray<arc4.Address>(new arc4.Address(Bytes(new Uint8Array(Array(32).fill(0)))))
+
+    const dummyVerifierApp = ctx.any.application({ appLogs: [ABI_RETURN_VALUE_LOG_PREFIX.concat(Bytes.fromHex('80'))] })
+    ctx.setTemplateVar('VERIFIER_APP_ID', dummyVerifierApp.id)
+
+    // Act
+    const result = contract.addAddressToWhitelist(address, proof)
+
+    // Assert
+    expect(result.native).toEqual('')
+    expect(contract.whiteList(ctx.defaultSender).value).toEqual(true)    
+  })
+
+  it('returns error message if proof verification fails', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const address = ctx.any.arc4.address()
+    const proof = new arc4.DynamicArray<arc4.Address>(new arc4.Address(Bytes(new Uint8Array(Array(32).fill(0)))))
+    const dummyVerifierApp = ctx.any.application({ appLogs: [ABI_RETURN_VALUE_LOG_PREFIX.concat(Bytes(''))] })
+    ctx.setTemplateVar('VERIFIER_APP_ID', dummyVerifierApp.id)
+
+    // Act
+    const result = contract.addAddressToWhitelist(address, proof)
+
+    // Assert
+    expect(result.native).toEqual('Proof verification failed')
+  })
+
+  it('returns true if address is already in whitelist', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const dummyAccount = ctx.any.account({ optedApplications: [ctx.ledger.getApplicationForContract(contract)] })
+    contract.whiteList(dummyAccount).value = true
+
+    // Act
+    const result = contract.isOnWhitelist(new arc4.Address(dummyAccount))
+
+    // Assert
+    expect(result.native).toBe(true)
+  })
+
+  it('returns false if address is not in whitelist', () => {
+    // Arrange
+    const contract = ctx.contract.create(ZkWhitelistContract)
+    contract.create(ctx.any.arc4.str(10))
+
+    const dummyAccount = ctx.any.account({ optedApplications: [ctx.ledger.getApplicationForContract(contract)] })
+    contract.whiteList(dummyAccount).value = false
+
+    // Act
+    const result = contract.isOnWhitelist(new arc4.Address(dummyAccount))
+
+    // Assert
+    expect(result.native).toBe(false)
+  })
+})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,15 +6,16 @@ const jestConfig: JestConfigWithTsJest = {
     ...presetConfig,
     testMatch: ['**/*.test.ts'],
     testPathIgnorePatterns: ["<rootDir>/tealscript_contracts/", '@algorandfoundation/tealscript'],
-    coveragePathIgnorePatterns: ["<rootDir>/tealscript_contracts/",  '@algorandfoundation/tealscript'],
+    coveragePathIgnorePatterns: ["<rootDir>/tealscript_contracts/", '@algorandfoundation/tealscript'],
     modulePathIgnorePatterns: ["<rootDir>/tealscript_contracts/", '@algorandfoundation/tealscript'],
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],    
     transform: {
         '^.+\\.tsx?$': [
             'ts-jest',
             {
                 useESM: true,
                 astTransformers: {
-                    before: ['node_modules/@algorandfoundation/algorand-typescript-testing/test-transformer/index.mjs'],
+                    before: ['node_modules/@algorandfoundation/algorand-typescript-testing/test-transformer/jest-transformer.mjs'],
                 },
             },
         ],

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,6 @@
+import {beforeAll, expect} from '@jest/globals'
+import { addEqualityTesters } from '@algorandfoundation/algorand-typescript-testing'
+
+beforeAll(() => {    
+  addEqualityTesters({ expect })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,21 +7,23 @@
     "": {
       "name": "puya-ts-demo",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "vitest": "^2.1.2"
       },
       "devDependencies": {
         "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16",
-        "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.18",
+        "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.19",
         "@algorandfoundation/puya-ts": "^1.0.0-beta.23",
         "@algorandfoundation/tealscript": "0.105.5",
+        "@jest/globals": "^29.7.0",
         "@rollup/plugin-typescript": "^12.1.0",
         "@tsconfig/node20": "^20.1.4",
-        "@types/jest": "^29.5.14",
         "@types/node": "^22.10.6",
         "@types/node-fetch": "^2.6.12",
         "jest": "^29.7.0",
+        "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2"
@@ -37,9 +39,9 @@
       }
     },
     "node_modules/@algorandfoundation/algorand-typescript-testing": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript-testing/-/algorand-typescript-testing-1.0.0-beta.18.tgz",
-      "integrity": "sha512-F49K4RIt1rNEXmXPg/vE6Qo9UlrEjOMDwPA+ozJTVBb7ERkmcCZ/lCxVTnoEOsgYItHpBK9CEAAtOocPEHOJCA==",
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algorand-typescript-testing/-/algorand-typescript-testing-1.0.0-beta.19.tgz",
+      "integrity": "sha512-7WabsWRx8h7jfLoTVaWwZ0h+CpW6tjpKlWidS5Vec+SwkuO5AXYmZVWkDdFkeOuFqneYl4PT4PiTthGo1dLu3A==",
       "dev": true,
       "dependencies": {
         "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16",
@@ -82,16 +84,6 @@
         "puyats": "bin/run-cli.mjs"
       }
     },
-    "node_modules/@algorandfoundation/puya-ts/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@algorandfoundation/puya-ts/node_modules/typescript": {
       "version": "5.7.2",
       "dev": true,
@@ -103,22 +95,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@algorandfoundation/puya-ts/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@algorandfoundation/tealscript": {
@@ -346,16 +322,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -1849,13 +1815,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1915,9 +1881,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
-      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
+      "integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
       "cpu": [
         "arm"
       ],
@@ -1928,9 +1894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
-      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
+      "integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
       "cpu": [
         "arm64"
       ],
@@ -1941,9 +1907,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
-      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
+      "integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
       "cpu": [
         "arm64"
       ],
@@ -1954,9 +1920,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
-      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
+      "integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
       "cpu": [
         "x64"
       ],
@@ -1967,9 +1933,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
-      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
+      "integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1980,9 +1946,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
-      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
+      "integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
       "cpu": [
         "x64"
       ],
@@ -1993,9 +1959,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
-      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
+      "integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
       "cpu": [
         "arm"
       ],
@@ -2006,9 +1972,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
-      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
+      "integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
       "cpu": [
         "arm"
       ],
@@ -2019,9 +1985,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
-      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
+      "integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
       "cpu": [
         "arm64"
       ],
@@ -2032,9 +1998,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
-      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
+      "integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
       "cpu": [
         "arm64"
       ],
@@ -2045,9 +2011,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
-      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
+      "integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
       "cpu": [
         "loong64"
       ],
@@ -2058,9 +2024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
-      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
+      "integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2071,9 +2037,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
-      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
+      "integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
       "cpu": [
         "riscv64"
       ],
@@ -2084,9 +2050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
-      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
+      "integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
       "cpu": [
         "s390x"
       ],
@@ -2097,9 +2063,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
-      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
+      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
       "cpu": [
         "x64"
       ],
@@ -2110,9 +2076,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
-      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
+      "integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
       "cpu": [
         "x64"
       ],
@@ -2123,9 +2089,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
-      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
+      "integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
       "cpu": [
         "arm64"
       ],
@@ -2136,9 +2102,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
-      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
+      "integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
       "cpu": [
         "ia32"
       ],
@@ -2149,9 +2115,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
-      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
+      "integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
       "cpu": [
         "x64"
       ],
@@ -2347,21 +2313,10 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "22.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
-      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
+      "version": "22.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.2.tgz",
+      "integrity": "sha512-Z+r8y3XL9ZpI2EY52YYygAFmo2/oWfNSj4BCpAXE2McAexDk8VcnBMGC9Djn9gTKt4d2T/hhXqmPzo4hfIXtTg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2404,13 +2359,13 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
-      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.8",
-        "@vitest/utils": "2.1.8",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
         "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -2419,12 +2374,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
-      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.8",
+        "@vitest/spy": "2.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.12"
       },
@@ -2454,9 +2409,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
-      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -2466,12 +2421,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
-      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.8",
+        "@vitest/utils": "2.1.9",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -2479,12 +2434,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
-      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.8",
+        "@vitest/pretty-format": "2.1.9",
         "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
       },
@@ -2493,9 +2448,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
-      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
@@ -2505,18 +2460,25 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
-      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.8",
+        "@vitest/pretty-format": "2.1.9",
         "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -2574,13 +2536,13 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2656,6 +2618,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2920,6 +2892,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3284,6 +3306,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -3333,6 +3378,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3388,6 +3451,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3412,9 +3490,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.97",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
-      "integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
+      "version": "1.5.98",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.98.tgz",
+      "integrity": "sha512-bI/LbtRBxU2GzK7KK5xxFd2y9Lf9XguHooPYbcXWy6wUoT8NMnffsvRhPmSeUHLSDKAEtKuTaEtK4Ms15zkIEA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3464,11 +3542,44 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3640,9 +3751,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3709,6 +3820,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -3741,6 +3862,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3749,9 +3886,9 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3792,6 +3929,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3800,6 +3962,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3862,6 +4038,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3877,6 +4066,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash.js": {
@@ -4011,6 +4226,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4077,12 +4308,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4179,9 +4433,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.3.tgz",
+      "integrity": "sha512-oSwM7q8PTHQWuZAlp995iPpPJ4Vkl7qT0ZRD+9duL9j2oBy6KcTfyxc8mEuHJYC+z/kbps80aJLkaNzTOrf/kw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5505,6 +5759,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5516,6 +5790,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -5566,19 +5873,19 @@
       "license": "MIT"
     },
     "node_modules/loupe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
@@ -5634,6 +5941,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {
@@ -5741,6 +6058,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5858,6 +6185,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5882,6 +6219,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -5965,6 +6329,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -6026,6 +6477,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -6084,13 +6545,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6103,9 +6564,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6113,6 +6574,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/polytype": {
@@ -6126,9 +6602,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6154,9 +6630,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+      "integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6182,19 +6658,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/prompts": {
@@ -6331,10 +6794,70 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/rollup": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
+      "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -6347,25 +6870,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.30.1",
-        "@rollup/rollup-android-arm64": "4.30.1",
-        "@rollup/rollup-darwin-arm64": "4.30.1",
-        "@rollup/rollup-darwin-x64": "4.30.1",
-        "@rollup/rollup-freebsd-arm64": "4.30.1",
-        "@rollup/rollup-freebsd-x64": "4.30.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
-        "@rollup/rollup-linux-arm64-musl": "4.30.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-musl": "4.30.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
-        "@rollup/rollup-win32-x64-msvc": "4.30.1",
+        "@rollup/rollup-android-arm-eabi": "4.34.6",
+        "@rollup/rollup-android-arm64": "4.34.6",
+        "@rollup/rollup-darwin-arm64": "4.34.6",
+        "@rollup/rollup-darwin-x64": "4.34.6",
+        "@rollup/rollup-freebsd-arm64": "4.34.6",
+        "@rollup/rollup-freebsd-x64": "4.34.6",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.6",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.6",
+        "@rollup/rollup-linux-arm64-musl": "4.34.6",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.6",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.6",
+        "@rollup/rollup-linux-x64-gnu": "4.34.6",
+        "@rollup/rollup-linux-x64-musl": "4.34.6",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.6",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.6",
+        "@rollup/rollup-win32-x64-msvc": "4.34.6",
         "fsevents": "~2.3.2"
       }
     },
@@ -6401,6 +6924,24 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -6834,6 +7375,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7038,6 +7592,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/upath": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
@@ -7162,9 +7726,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
-      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -7183,33 +7747,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/vitest": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
-      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.8",
-        "@vitest/mocker": "2.1.8",
-        "@vitest/pretty-format": "^2.1.8",
-        "@vitest/runner": "2.1.8",
-        "@vitest/snapshot": "2.1.8",
-        "@vitest/spy": "2.1.8",
-        "@vitest/utils": "2.1.8",
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
         "chai": "^5.1.2",
         "debug": "^4.3.7",
         "expect-type": "^1.1.0",
@@ -7221,7 +7771,7 @@
         "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.8",
+        "vite-node": "2.1.9",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -7236,8 +7786,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.8",
-        "@vitest/ui": "2.1.8",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -7298,19 +7848,19 @@
       }
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -7427,6 +7977,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7471,6 +8034,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -7570,9 +8146,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "postinstall": "patch-package",
     "build:puya": "puya-ts build contracts",
     "build:tealscript": "tealscript tealscript_contracts/kitchen-sink-tealscript.algo.ts tealscript_contracts/artifacts",
-    "test:jest": "tsc && node --experimental-vm-modules node_modules/.bin/jest",
+    "test:jest": "tsc && node --experimental-vm-modules node_modules/jest/bin/jest",
     "test:vitest": "vitest run"
   },
   "type": "module",
@@ -14,15 +15,16 @@
   "description": "",
   "devDependencies": {
     "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16",
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.18",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.19",
     "@algorandfoundation/puya-ts": "^1.0.0-beta.23",
     "@algorandfoundation/tealscript": "0.105.5",
+    "@jest/globals": "^29.7.0",
     "@rollup/plugin-typescript": "^12.1.0",
     "@tsconfig/node20": "^20.1.4",
-    "@types/jest": "^29.5.14",
     "@types/node": "^22.10.6",
     "@types/node-fetch": "^2.6.12",
     "jest": "^29.7.0",
+    "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2"

--- a/patches/ts-jest+29.2.5.patch
+++ b/patches/ts-jest+29.2.5.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/ts-jest/dist/legacy/compiler/ts-compiler.js b/node_modules/ts-jest/dist/legacy/compiler/ts-compiler.js
+index 5198f8f..addb47c 100644
+--- a/node_modules/ts-jest/dist/legacy/compiler/ts-compiler.js
++++ b/node_modules/ts-jest/dist/legacy/compiler/ts-compiler.js
+@@ -234,7 +234,7 @@ var TsCompiler = /** @class */ (function () {
+         var _a;
+         // Initialize memory cache for typescript compiler
+         this._parsedTsConfig.fileNames
+-            .filter(function (fileName) { return constants_1.TS_TSX_REGEX.test(fileName) && !_this.configSet.isTestFile(fileName); })
++            .filter(function (fileName) { return constants_1.TS_TSX_REGEX.test(fileName); })
+             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+             .forEach(function (fileName) { return _this._fileVersionCache.set(fileName, 0); });
+         /* istanbul ignore next */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "target": "ES2023",
     "module": "ESNext",
-    "lib": ["ES2023"],
+    "lib": ["ESNext"],
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import { defineConfig } from 'vitest/config'
-import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/test-transformer'
+import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/vitest-transformer'
 
 export default defineConfig({
   esbuild: {},
@@ -9,8 +9,7 @@ export default defineConfig({
     setupFiles: 'vitest.setup.ts',
   },
   plugins: [
-    typescript({
-      tsconfig: './tsconfig.json',
+    typescript({      
       transformers: {
         before: [puyaTsTransformer],
       },


### PR DESCRIPTION
*Changes*:
- add more example contracts for both vitest and jest
- add a patch for `ts-jest` as it was excluding the test file being transformed from `program.getSourceFiles()` list which caused the algorand-typescript-testing transformer to not get the type information it needed from typescript, manifesting `This method is intentionally not implemented` errors during test runs.
- swapped `@types/jest` with `@jest/globals` package as it is more up to date
- add equality testers for jest
- use `node_modules/jest/bin/jest` instead of `node_modules/.bin/jest` to make it work on all platforms
